### PR TITLE
fix: improve proxy error handling to expose root cause of network fai…

### DIFF
--- a/frontend/src/lib/proxy-utils.ts
+++ b/frontend/src/lib/proxy-utils.ts
@@ -75,13 +75,26 @@ export async function proxyPublicApiRequest(request: Request, targetPath: string
     if (error.name === "AbortError") {
       return NextResponse.json({ error: "Upstream timeout" }, { status: 504 })
     }
-    if (error.cause?.code === "ECONNREFUSED") {
+
+    const causeCode = error.cause?.code
+    console.error(`[Proxy] Error fetching ${finalUrl}: ${error.message} (cause: ${causeCode ?? "unknown"})`)
+
+    if (causeCode === "ECONNREFUSED") {
       return NextResponse.json({ error: "Backend unavailable" }, { status: 503 })
     }
-    console.error(`[Proxy] Error: ${error.message}`)
+
+    if (causeCode === "ECONNRESET" || causeCode === "EPIPE" || error.message?.includes("socket hang up")) {
+      return NextResponse.json({ error: "Backend connection reset" }, { status: 503 })
+    }
+
+    if (causeCode === "ETIMEDOUT" || causeCode === "ENOTFOUND") {
+      return NextResponse.json({ error: "Backend unreachable" }, { status: 503 })
+    }
+
     return NextResponse.json({ error: "Internal Proxy Error" }, { status: 500 })
   }
 }
+
 
 export async function proxyRequest(request: Request, targetPath: string, options: ProxyOptions = {}) {
   const { timeoutMs = 30000, defaultBackendUrl = DEFAULT_BACKEND_URL } = options
@@ -169,13 +182,21 @@ export async function proxyRequest(request: Request, targetPath: string, options
       return NextResponse.json({ error: "Upstream timeout" }, { status: 504 })
     }
 
-    // Check for connection refused (common in dev/deploy misconfig)
-    if (error.cause?.code === "ECONNREFUSED") {
-      console.error(`[Proxy] Connection Refused to ${finalUrl}. Check BACKEND_URL or if backend is running.`)
+    const causeCode = error.cause?.code
+    console.error(`[Proxy] Error fetching ${finalUrl}: ${error.message} (cause: ${causeCode ?? "unknown"})`)
+
+    if (causeCode === "ECONNREFUSED") {
       return NextResponse.json({ error: "Backend unavailable" }, { status: 503 })
     }
 
-    console.error(`[Proxy] Error: ${error.message}`)
+    if (causeCode === "ECONNRESET" || causeCode === "EPIPE" || error.message?.includes("socket hang up")) {
+      return NextResponse.json({ error: "Backend connection reset" }, { status: 503 })
+    }
+
+    if (causeCode === "ETIMEDOUT" || causeCode === "ENOTFOUND") {
+      return NextResponse.json({ error: "Backend unreachable" }, { status: 503 })
+    }
+
     return NextResponse.json({ error: "Internal Proxy Error" }, { status: 500 })
   }
 }


### PR DESCRIPTION
…lures

Previously, any fetch error that wasn't AbortError or ECONNREFUSED fell through to a generic "Internal Proxy Error" (500), making it impossible to distinguish backend crashes (ECONNRESET/EPIPE) from connectivity issues (ETIMEDOUT/ENOTFOUND) during long-running bulk scan operations.

- Log error.cause?.code alongside the message for all proxy errors
- Return "Backend connection reset" (503) for ECONNRESET/EPIPE/socket hang up
- Return "Backend unreachable" (503) for ETIMEDOUT/ENOTFOUND
- Apply fix to both proxyRequest and proxyPublicApiRequest