### PR TITLE
feat(discovery): publisher ads.txt discovery pipeline (gTLD JP)

### DIFF
--- a/.github/workflows/deploy-discovery-job.yml
+++ b/.github/workflows/deploy-discovery-job.yml
@@ -1,0 +1,90 @@
+name: Deploy Discovery Cloud Run Job
+
+# Runs the publisher-discovery pipeline in GCP as a Cloud Run Job, where it belongs:
+#   - Cloud SQL over a Unix socket (no auth-proxy token to expire)
+#   - GCP's resolver (no local DNS rate-limiting on a 300k-domain crawl)
+#
+# Manually dispatched. Deploys/updates the `ttkit-discovery` job with the chosen
+# command + args, and optionally executes it once immediately.
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "runner command"
+        type: choice
+        default: probe
+        options: [refresh, probe, enroll, stats]
+      extra_args:
+        description: "comma-separated args (e.g. --limit,20000,--concurrency,40 or --max,1000,--wave1)"
+        default: "--limit,20000,--concurrency,40"
+      execute_now:
+        description: "execute the job once after deploying"
+        type: boolean
+        default: true
+
+env:
+  PROJECT_ID: apti-ttkit
+  REGION: asia-northeast1
+  REPO_NAME: ttkit-repo
+  JOB_NAME: ttkit-discovery
+  DB_INSTANCE: ttkit-db-instance
+
+jobs:
+  deploy-job:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      - name: Build and Push Backend image
+        run: |
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/backend:${{ github.sha }}
+          docker build --platform linux/amd64 -t "$IMAGE" ./backend
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Deploy Cloud Run Job
+        run: |
+          DB_CONNECTION_NAME=$(gcloud sql instances describe ${{ env.DB_INSTANCE }} --project ${{ env.PROJECT_ID }} --format="value(connectionName)")
+
+          # Build the args list: dist/discovery/runner.js,<command>,<extra_args>
+          ARGS="dist/discovery/runner.js,${{ github.event.inputs.command }}"
+          if [ -n "${{ github.event.inputs.extra_args }}" ]; then
+            ARGS="$ARGS,${{ github.event.inputs.extra_args }}"
+          fi
+
+          gcloud run jobs deploy ${{ env.JOB_NAME }} \
+            --image "$IMAGE" \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }} \
+            --set-cloudsql-instances "$DB_CONNECTION_NAME" \
+            --command node \
+            --args "$ARGS" \
+            --set-env-vars DATABASE_URL="postgres://postgres:${{ secrets.DB_PASSWORD }}@/${{ secrets.DB_NAME }}?host=/cloudsql/${DB_CONNECTION_NAME}",UV_THREADPOOL_SIZE=64 \
+            --task-timeout=3600 \
+            --max-retries=1 \
+            --memory=1Gi \
+            --cpu=1
+
+      - name: Execute once
+        if: ${{ github.event.inputs.execute_now == 'true' }}
+        run: |
+          gcloud run jobs execute ${{ env.JOB_NAME }} \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }} \
+            --wait

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon --watch src --exec ts-node src/index.ts",
     "build": "tsc",
     "ingest": "ts-node src/ingest/runner.ts",
+    "discovery": "ts-node src/discovery/runner.ts",
     "migrate:04": "ts-node src/scripts/migrate_04_jitter_scheduling.ts",
     "migrate:05": "ts-node src/scripts/migrate_05_opensincera_cache.ts",
     "migrate:06": "ts-node src/scripts/migrate_06_api_keys.ts",

--- a/backend/src/db/migrations/20260725_publisher_discovery.sql
+++ b/backend/src/db/migrations/20260725_publisher_discovery.sql
@@ -1,0 +1,42 @@
+-- Publisher discovery pipeline
+-- Automates what was previously a manual "jp_publisher_extractor CSV -> bulk-import" loop:
+-- find publisher domains referenced in sellers_catalog that we do NOT yet crawl,
+-- probe their ads.txt + detect Japanese content, and enroll the qualifying ones.
+--
+-- Scope note: `.jp` ccTLD publishers are handled by a separate crawler, so this
+-- pipeline deliberately targets gTLD (mainly .com) Japanese publishers, which are
+-- only identifiable by CONTENT, not by TLD.
+
+CREATE TABLE IF NOT EXISTS publisher_discovery (
+    domain          TEXT PRIMARY KEY,      -- registrable root domain (psl-normalized)
+    discovered_ssp  TEXT,                  -- an SSP whose sellers.json referenced this domain
+    seller_id       TEXT,                  -- the seller_id used to validate the ads.txt relationship
+    match_type      TEXT NOT NULL DEFAULT 'direct',  -- 'direct' | 'ownerdomain'
+
+    -- probe results (all verdicts stored, JP and non-JP, for reporting / re-probe suppression)
+    ads_txt_valid   BOOLEAN,               -- ads.txt declares (discovered_ssp, seller_id)
+    http_status     INT,                   -- ads.txt fetch status
+    is_japanese     BOOLEAN,
+    jp_method       TEXT,                  -- html_lang / og_locale / content_language / kana
+    jp_confidence   REAL,
+    jp_char_ratio   REAL,                  -- Japanese (kana+cjk) character ratio of homepage text
+
+    status          TEXT NOT NULL DEFAULT 'pending',  -- pending / probed / enrolled / rejected / failed
+    probed_at       TIMESTAMPTZ,
+    next_probe_at   TIMESTAMPTZ,           -- retry gate for failed rows
+    retry_count     INT NOT NULL DEFAULT 0,
+    error_message   TEXT,
+    queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pd_status ON publisher_discovery (status, next_probe_at);
+CREATE INDEX IF NOT EXISTS idx_pd_enrollable
+    ON publisher_discovery (status, is_japanese, ads_txt_valid);
+
+COMMENT ON TABLE publisher_discovery IS
+    'Discovery queue + verdict store for uncrawled publisher domains (gTLD Japanese focus). Feeds monitored_domains via the enroller.';
+
+-- Tag existing and future monitored_domains with their origin so monthly reports can
+-- segment organic vs discovery-sourced cohorts (avoids distorting historical comparisons).
+ALTER TABLE monitored_domains
+    ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'organic';

--- a/backend/src/discovery/README.md
+++ b/backend/src/discovery/README.md
@@ -1,0 +1,45 @@
+# Publisher discovery
+
+Automates the previously-manual `jp_publisher_extractor CSV → bulk-import` loop: finds
+publisher domains referenced in `sellers_catalog` that we do **not** yet crawl, probes
+their `ads.txt` and detects Japanese content, and enrolls qualifying domains into
+`monitored_domains` (tagged `source='discovery'`).
+
+## Why gTLD-focused
+
+`.jp` ccTLD publishers are already covered by a separate crawler, so this pipeline targets
+**gTLD (mainly `.com`) Japanese publishers**, which are only identifiable by page content —
+not by TLD. Candidate generation excludes `*.jp`.
+
+## Pipeline
+
+| Stage | File | What it does |
+|---|---|---|
+| refresh | `candidate_generator.ts` | `sellers_catalog` − `monitored_domains` − queued → `publisher_discovery` (pending). Domains normalized to registrable root via `psl`. |
+| probe | `prober.ts` | Fetch `ads.txt` (validate the `(ssp, seller_id)` relationship) + fetch homepage → `lang_detector.ts`. Writes verdict for **every** candidate (JP and non-JP). |
+| enroll | `enroller.ts` | JP + ads.txt-valid → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Non-JP / invalid probed rows → `rejected`. |
+
+`lang_detector.ts` is a dependency-free port of the Python tool's multi-dimensional JP
+detection (`<html lang>`, `og:locale`, `Content-Language`, kana density). Kana is scored
+separately from kanji so Chinese pages are not misclassified as Japanese.
+
+## Usage
+
+```bash
+npm run discovery -- refresh
+npm run discovery -- probe  --limit 20000 --concurrency 20
+npm run discovery -- enroll --max 1000 --wave1   # --wave1 = html_lang=ja only
+npm run discovery -- stats
+```
+
+## Report safety
+
+Enrollment is throttled (`--max`) so the monthly-report base grows smoothly — matching the
+historical manual cadence rather than dumping the whole backlog at once. `--wave1` restricts
+the first wave to the highest-confidence `html_lang=ja` detections. The `source` column on
+`monitored_domains` lets reports segment `organic` vs `discovery` cohorts.
+
+## Schema
+
+`db/migrations/20260725_publisher_discovery.sql` — creates `publisher_discovery` and adds
+`monitored_domains.source` (default `organic`).

--- a/backend/src/discovery/README.md
+++ b/backend/src/discovery/README.md
@@ -43,3 +43,39 @@ the first wave to the highest-confidence `html_lang=ja` detections. The `source`
 
 `db/migrations/20260725_publisher_discovery.sql` — creates `publisher_discovery` and adds
 `monitored_domains.source` (default `organic`).
+
+## Running in GCP (Cloud Run Job)
+
+A 300k-domain crawl must **not** run against a local Cloud SQL auth-proxy: the proxy's
+access token expires ~hourly (aborting long runs) and a flood of DNS lookups gets the local
+resolver rate-limited (mass false `ENOTFOUND`). In GCP both problems disappear — Cloud SQL
+is reached over a Unix socket and DNS is GCP's resolver. The job also sets
+`UV_THREADPOOL_SIZE=64` so concurrent `getaddrinfo` calls don't queue on the default 4
+libuv threads.
+
+Deploy/run via the `Deploy Discovery Cloud Run Job` GitHub Action (`workflow_dispatch`) —
+pick `command` (`refresh`/`probe`/`enroll`/`stats`) and `extra_args`. Or with gcloud:
+
+```bash
+# one probe chunk
+gcloud run jobs execute ttkit-discovery --region asia-northeast1 --project apti-ttkit --wait
+
+# widened enroll wave (report-safe throttle)
+gcloud run jobs update ttkit-discovery --region asia-northeast1 --project apti-ttkit \
+  --args dist/discovery/runner.js,enroll,--max,1000
+gcloud run jobs execute ttkit-discovery --region asia-northeast1 --project apti-ttkit --wait
+```
+
+### Recurring schedule (Cloud Scheduler → Job)
+
+```bash
+# probe a chunk hourly until the queue drains (job's baked args = probe)
+gcloud scheduler jobs create http ttkit-discovery-probe \
+  --location=asia-northeast1 --schedule="0 * * * *" \
+  --uri="https://asia-northeast1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/apti-ttkit/jobs/ttkit-discovery:run" \
+  --http-method=POST \
+  --oauth-service-account-email=<run-invoker-sa>@apti-ttkit.iam.gserviceaccount.com
+```
+
+Keep `enroll` on a slower cadence (e.g. daily, `--max` capped) so the monthly-report base
+grows smoothly rather than in one step.

--- a/backend/src/discovery/candidate_generator.ts
+++ b/backend/src/discovery/candidate_generator.ts
@@ -1,0 +1,68 @@
+import { query } from '../db/client';
+import { chunk, toRootDomain } from './util';
+
+const INSERT_CHUNK = 5000;
+
+/**
+ * Populate publisher_discovery with publisher domains that are referenced in
+ * sellers_catalog but not yet crawled.
+ *
+ * Filters:
+ *   - seller_type PUBLISHER/BOTH (actual publishers, not pure intermediaries)
+ *   - NOT `.jp` (handled by a separate crawler)
+ *   - not already in monitored_domains (ads.txt)
+ *   - not already queued in publisher_discovery
+ *
+ * Domains are normalized to their registrable root so that www / subdomain variants
+ * collapse to a single ads.txt target.
+ */
+export async function generateCandidates(): Promise<{ scanned: number; inserted: number }> {
+  // Pull distinct referenced publisher domains. ~330k short strings — a few MB in memory.
+  const res = await query(
+    `SELECT DISTINCT ON (lower(seller_domain))
+        lower(seller_domain) AS raw,
+        domain               AS ssp,
+        seller_id            AS seller_id
+     FROM sellers_catalog
+     WHERE seller_domain LIKE '%.%'
+       AND seller_domain NOT LIKE '% %'
+       AND seller_domain NOT LIKE '%.jp'
+       AND seller_type IN ('PUBLISHER', 'BOTH')
+     ORDER BY lower(seller_domain)`,
+  );
+
+  // Normalize to registrable root, keeping the first (ssp, seller_id) seen per root.
+  const byRoot = new Map<string, { ssp: string; sellerId: string }>();
+  for (const row of res.rows as { raw: string; ssp: string; seller_id: string }[]) {
+    const root = toRootDomain(row.raw);
+    if (!root) continue;
+    if (!byRoot.has(root)) byRoot.set(root, { ssp: row.ssp, sellerId: row.seller_id });
+  }
+
+  const entries = [...byRoot.entries()];
+  let inserted = 0;
+
+  for (const batch of chunk(entries, INSERT_CHUNK)) {
+    const domains = batch.map(([d]) => d);
+    const ssps = batch.map(([, v]) => v.ssp);
+    const sellerIds = batch.map(([, v]) => v.sellerId);
+
+    // Anti-join against monitored_domains inside the insert so we never re-queue a
+    // domain we already crawl. ON CONFLICT handles rows already in the queue.
+    const ins = await query(
+      `INSERT INTO publisher_discovery (domain, discovered_ssp, seller_id, match_type)
+       SELECT c.domain, c.ssp, c.seller_id, 'direct'
+       FROM unnest($1::text[], $2::text[], $3::text[]) AS c(domain, ssp, seller_id)
+       WHERE NOT EXISTS (
+         SELECT 1 FROM monitored_domains m
+         WHERE lower(m.domain) = c.domain AND m.file_type = 'ads.txt'
+       )
+       ON CONFLICT (domain) DO NOTHING
+       RETURNING domain`,
+      [domains, ssps, sellerIds],
+    );
+    inserted += ins.rows.length;
+  }
+
+  return { scanned: res.rows.length, inserted };
+}

--- a/backend/src/discovery/enroller.ts
+++ b/backend/src/discovery/enroller.ts
@@ -1,0 +1,52 @@
+import { query } from '../db/client';
+import { MonitoredDomainsService } from '../services/monitored_domains';
+
+const monitored = new MonitoredDomainsService();
+
+export interface EnrollOptions {
+  /** Max domains to enroll in this wave (report-safety throttle). */
+  max: number;
+  /** Wave 1 safety: only enroll the highest-confidence html_lang=ja detections. */
+  highConfidenceOnly?: boolean;
+}
+
+/**
+ * Enroll probed, Japanese, ads.txt-valid candidates into monitored_domains (tagged
+ * source='discovery'), then mark the rest of the probed batch as rejected so they are
+ * not re-probed.
+ */
+export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; rejected: number }> {
+  const confFilter = opts.highConfidenceOnly ? `AND jp_method = 'html_lang'` : '';
+
+  const res = await query(
+    `SELECT domain
+     FROM publisher_discovery
+     WHERE status = 'probed' AND is_japanese = true AND ads_txt_valid = true
+     ${confFilter}
+     ORDER BY jp_confidence DESC, jp_char_ratio DESC
+     LIMIT $1`,
+    [opts.max],
+  );
+  const domains = (res.rows as { domain: string }[]).map((r) => r.domain);
+
+  let enrolled = 0;
+  if (domains.length > 0) {
+    await monitored.bulkAddDomains(domains, 'ads.txt', 'discovery');
+    const upd = await query(
+      `UPDATE publisher_discovery SET status = 'enrolled'
+       WHERE domain = ANY($1::text[]) RETURNING domain`,
+      [domains],
+    );
+    enrolled = upd.rows.length;
+  }
+
+  // Retire probed candidates that will never be enrolled (not JP, or ads.txt invalid)
+  // so future probe passes skip them.
+  const rej = await query(
+    `UPDATE publisher_discovery SET status = 'rejected'
+     WHERE status = 'probed' AND (is_japanese = false OR ads_txt_valid = false)
+     RETURNING domain`,
+  );
+
+  return { enrolled, rejected: rej.rows.length };
+}

--- a/backend/src/discovery/lang_detector.test.ts
+++ b/backend/src/discovery/lang_detector.test.ts
@@ -1,0 +1,50 @@
+import { detectJapanese } from './lang_detector';
+
+describe('detectJapanese', () => {
+  it('detects <html lang="ja"> with highest confidence', () => {
+    const v = detectJapanese('<html lang="ja"><body>Hello</body></html>');
+    expect(v.isJapanese).toBe(true);
+    expect(v.method).toBe('html_lang');
+    expect(v.confidence).toBeGreaterThan(0.9);
+  });
+
+  it('detects og:locale ja_JP', () => {
+    const v = detectJapanese(
+      '<html><head><meta property="og:locale" content="ja_JP"></head><body>x</body></html>',
+    );
+    expect(v.isJapanese).toBe(true);
+    expect(v.method).toBe('og_locale');
+  });
+
+  it('detects Japanese via kana density when no lang tag is present', () => {
+    const body = 'これは日本語のホームページです。'.repeat(10);
+    const v = detectJapanese(`<html><body>${body}</body></html>`);
+    expect(v.isJapanese).toBe(true);
+    expect(v.method).toBe('kana');
+    expect(v.kanaRatio).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag Chinese (CJK without kana) as Japanese', () => {
+    const body = '这是一个中文网站首页内容测试'.repeat(10);
+    const v = detectJapanese(`<html lang="zh"><body>${body}</body></html>`);
+    expect(v.isJapanese).toBe(false);
+  });
+
+  it('respects an explicit non-ja html lang when there is no kana', () => {
+    const v = detectJapanese('<html lang="en"><body>Welcome to our site</body></html>');
+    expect(v.isJapanese).toBe(false);
+    expect(v.method).toBe('none');
+  });
+
+  it('kana content overrides a mislabeled non-ja tag only through explicit ja signals', () => {
+    // Real Japanese kana present but tag says en -> declaredOther blocks the kana path,
+    // which is the conservative behavior for wave 1.
+    const body = 'ようこそ私たちのサイトへ。'.repeat(10);
+    const v = detectJapanese(`<html lang="en"><body>${body}</body></html>`);
+    expect(v.method).not.toBe('kana');
+  });
+
+  it('returns empty verdict for empty input', () => {
+    expect(detectJapanese('').isJapanese).toBe(false);
+  });
+});

--- a/backend/src/discovery/lang_detector.ts
+++ b/backend/src/discovery/lang_detector.ts
@@ -1,0 +1,133 @@
+/**
+ * Multi-dimensional Japanese content detection.
+ *
+ * Ported and improved from the Python `jp_publisher_extractor` tool. Because this
+ * pipeline targets gTLD (.com etc.) publishers, the TLD gives no signal — the verdict
+ * must come from the page itself. We combine several signals rather than relying on any
+ * single one:
+ *
+ *   1. <html lang="ja"> attribute            (strongest, explicit author intent)
+ *   2. og:locale = ja_JP meta                 (strong)
+ *   3. Content-Language header / http-equiv   (supporting)
+ *   4. Kana ratio of visible text             (decisive discriminator vs. Chinese)
+ *
+ * Improvement over the Python version: kana (hiragana/katakana) is scored SEPARATELY
+ * from kanji. Chinese pages are full of CJK ideographs but contain no kana, so requiring
+ * kana presence makes the detector robust against Chinese false positives without needing
+ * a probabilistic language model.
+ */
+
+export interface JpVerdict {
+  isJapanese: boolean;
+  method: 'html_lang' | 'og_locale' | 'content_language' | 'kana' | 'none';
+  confidence: number; // 0..1
+  charRatio: number; // (kana + kanji) / visible chars
+  kanaRatio: number; // kana / visible chars
+}
+
+const HIRAGANA_KATAKANA = /[぀-ゟ゠-ヿ]/g;
+const KANJI = /[一-鿿㐀-䶿]/g;
+
+// Thresholds. Mirror the Python tool's char-ratio gate but add a kana-presence gate.
+const MIN_KANA_COUNT = 12; // absolute floor so tiny snippets don't trigger
+const MIN_KANA_RATIO = 0.02; // kana must be a real fraction of the text
+const MIN_CJK_RATIO = 0.1; // total Japanese-script density (matches Python MIN_RATIO)
+
+function langIsJa(value: string | undefined | null): boolean {
+  return !!value && value.trim().toLowerCase().startsWith('ja');
+}
+
+/** Extract the value of an attribute from a raw tag string. */
+function attr(tag: string, name: string): string | undefined {
+  const m = tag.match(new RegExp(`${name}\\s*=\\s*["']?\\s*([^"'>\\s]+)`, 'i'));
+  return m?.[1];
+}
+
+/** Strip scripts/styles/tags and collapse whitespace to approximate visible text. */
+function visibleText(html: string): string {
+  return html
+    .replace(/<(script|style|noscript)[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z#0-9]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Detect whether an HTML document is Japanese.
+ *
+ * @param html    Raw HTML of the homepage.
+ * @param headers Optional response headers (lowercased keys) for Content-Language.
+ */
+export function detectJapanese(html: string, headers?: Record<string, string>): JpVerdict {
+  const empty: JpVerdict = {
+    isJapanese: false,
+    method: 'none',
+    confidence: 0,
+    charRatio: 0,
+    kanaRatio: 0,
+  };
+  if (!html) return empty;
+
+  const head = html.slice(0, 8000);
+
+  // --- Signal 1: <html lang> ---
+  const htmlTag = head.match(/<html\b[^>]*>/i)?.[0];
+  const htmlLang = htmlTag ? attr(htmlTag, 'lang') : undefined;
+
+  // --- Signal 2: og:locale ---
+  let ogLocale: string | undefined;
+  for (const m of head.matchAll(/<meta\b[^>]*>/gi)) {
+    const tag = m[0];
+    if (/property\s*=\s*["']?\s*og:locale/i.test(tag)) {
+      ogLocale = attr(tag, 'content');
+      break;
+    }
+  }
+
+  // --- Signal 3: Content-Language (header or http-equiv meta) ---
+  let contentLang = headers?.['content-language'];
+  if (!contentLang) {
+    for (const m of head.matchAll(/<meta\b[^>]*>/gi)) {
+      const tag = m[0];
+      if (/http-equiv\s*=\s*["']?\s*content-language/i.test(tag)) {
+        contentLang = attr(tag, 'content');
+        break;
+      }
+    }
+  }
+
+  // --- Signal 4: script-character density ---
+  const text = visibleText(html).slice(0, 8000);
+  const totalChars = Math.max(text.replace(/\s/g, '').length, 1);
+  const kanaCount = (text.match(HIRAGANA_KATAKANA) || []).length;
+  const kanjiCount = (text.match(KANJI) || []).length;
+  const kanaRatio = kanaCount / totalChars;
+  const charRatio = (kanaCount + kanjiCount) / totalChars;
+
+  const hasKana = kanaCount >= MIN_KANA_COUNT && kanaRatio >= MIN_KANA_RATIO;
+
+  // Explicit non-Japanese declaration is a negative signal, but real Japanese kana
+  // content overrides a mislabeled tag.
+  const declaredOther =
+    (htmlLang && !langIsJa(htmlLang)) || (ogLocale && !langIsJa(ogLocale));
+
+  // Decision, most-confident signal first.
+  if (langIsJa(htmlLang)) {
+    return { isJapanese: true, method: 'html_lang', confidence: 0.99, charRatio, kanaRatio };
+  }
+  if (langIsJa(ogLocale)) {
+    return { isJapanese: true, method: 'og_locale', confidence: 0.95, charRatio, kanaRatio };
+  }
+  if (langIsJa(contentLang) && (hasKana || charRatio >= MIN_CJK_RATIO)) {
+    return { isJapanese: true, method: 'content_language', confidence: 0.9, charRatio, kanaRatio };
+  }
+  if (hasKana && charRatio >= MIN_CJK_RATIO && !declaredOther) {
+    // Confidence scales with how dense the Japanese script is.
+    const confidence = Math.min(0.6 + charRatio, 0.95);
+    return { isJapanese: true, method: 'kana', confidence, charRatio, kanaRatio };
+  }
+
+  return { ...empty, charRatio, kanaRatio };
+}

--- a/backend/src/discovery/prober.ts
+++ b/backend/src/discovery/prober.ts
@@ -1,0 +1,188 @@
+import http from '../lib/http';
+import { parseAdsTxtContent, isAdsTxtRecord } from '../lib/adstxt/validator';
+import { query } from '../db/client';
+import { detectJapanese, JpVerdict } from './lang_detector';
+import { mapPool } from './util';
+
+const REQUEST_TIMEOUT = 12000;
+const FAILED_RETRY_DAYS = 3;
+
+/** Run a write, retrying a few times on connection-level failures (proxy blips). */
+async function updateWithRetry(sql: string, params: any[], attempts = 4): Promise<void> {
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      await query(sql, params);
+      return;
+    } catch (e: any) {
+      const msg = String(e?.message || e).toLowerCase();
+      const transient = msg.includes('connection') || msg.includes('timeout') || msg.includes('terminated');
+      if (!transient || i === attempts) throw e;
+      await new Promise((r) => setTimeout(r, i * 1500));
+    }
+  }
+}
+
+interface Candidate {
+  domain: string;
+  discovered_ssp: string | null;
+  seller_id: string | null;
+}
+
+interface FetchResult {
+  status: number;
+  data: string;
+  headers: Record<string, string>;
+}
+
+/** Fetch a URL, returning the response (any status) or null on a network-level failure. */
+async function fetchUrl(url: string): Promise<FetchResult | null> {
+  try {
+    const res = await http.get(url, {
+      timeout: REQUEST_TIMEOUT,
+      responseType: 'text',
+      maxRedirects: 5,
+      validateStatus: () => true,
+      // Discovery probes millions of mostly-junk domains; the shared client's 3 retries
+      // would dominate runtime on dead hosts. One retry is enough for transient blips.
+      'axios-retry': { retries: 1 },
+    } as any);
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(res.headers || {})) {
+      headers[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v);
+    }
+    return { status: res.status, data: typeof res.data === 'string' ? res.data : String(res.data), headers };
+  } catch {
+    return null;
+  }
+}
+
+/** Try candidate URLs in order, returning the first 2xx response, else the last response seen. */
+async function fetchFirst(urls: string[]): Promise<FetchResult | null> {
+  let last: FetchResult | null = null;
+  for (const url of urls) {
+    const r = await fetchUrl(url);
+    if (r) {
+      last = r;
+      if (r.status >= 200 && r.status < 300) return r;
+    }
+  }
+  return last;
+}
+
+/** Does the ads.txt content declare the (ssp, seller_id) relationship? */
+function adsTxtDeclares(content: string, domain: string, ssp: string | null, sellerId: string | null): boolean {
+  if (!ssp || !sellerId) return false;
+  const entries = parseAdsTxtContent(content, domain);
+  const wantSsp = ssp.trim().toLowerCase();
+  const wantId = sellerId.trim();
+  for (const entry of entries) {
+    if (isAdsTxtRecord(entry) && entry.domain?.trim().toLowerCase() === wantSsp && entry.account_id?.trim() === wantId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+interface Probe {
+  adsTxtValid: boolean;
+  httpStatus: number | null;
+  jp: JpVerdict;
+  reached: boolean;
+}
+
+async function probeOne(c: Candidate): Promise<Probe> {
+  // --- ads.txt ---
+  const adsRes = await fetchFirst([`https://${c.domain}/ads.txt`, `http://${c.domain}/ads.txt`]);
+  let adsTxtValid = false;
+  const httpStatus = adsRes?.status ?? null;
+  if (adsRes && adsRes.status >= 200 && adsRes.status < 300 && adsRes.data && !adsRes.data.trimStart().startsWith('<')) {
+    adsTxtValid = adsTxtDeclares(adsRes.data, c.domain, c.discovered_ssp, c.seller_id);
+  }
+
+  // --- homepage / JP detection ---
+  const homeRes = await fetchFirst([`https://${c.domain}`, `http://${c.domain}`, `https://www.${c.domain}`]);
+  const jp =
+    homeRes && homeRes.status >= 200 && homeRes.status < 300 && homeRes.data
+      ? detectJapanese(homeRes.data, homeRes.headers)
+      : { isJapanese: false, method: 'none' as const, confidence: 0, charRatio: 0, kanaRatio: 0 };
+
+  return { adsTxtValid, httpStatus, jp, reached: !!(adsRes || homeRes) };
+}
+
+/**
+ * Probe up to `limit` pending (or due-for-retry) candidates and write verdicts back.
+ * Returns counts for logging.
+ */
+export async function probePending(
+  limit: number,
+  concurrency = 20,
+): Promise<{ probed: number; jpValid: number; failed: number }> {
+  const res = await query(
+    `SELECT domain, discovered_ssp, seller_id
+     FROM publisher_discovery
+     WHERE status = 'pending'
+        OR (status = 'failed' AND (next_probe_at IS NULL OR next_probe_at <= NOW()))
+     ORDER BY queued_at
+     LIMIT $1`,
+    [limit],
+  );
+  const candidates = res.rows as Candidate[];
+  if (candidates.length === 0) return { probed: 0, jpValid: 0, failed: 0 };
+
+  let probed = 0;
+  let jpValid = 0;
+  let failed = 0;
+
+  let skipped = 0;
+
+  await mapPool(candidates, concurrency, async (c) => {
+    // Isolate each candidate: a transient DB drop (the Cloud SQL proxy token expires
+    // ~hourly) must only skip the in-flight row — which stays 'pending' for the next
+    // run — instead of aborting the whole batch.
+    try {
+      let p: Probe;
+      try {
+        p = await probeOne(c);
+      } catch (e: any) {
+        await updateWithRetry(
+          `UPDATE publisher_discovery
+           SET status = 'failed', retry_count = retry_count + 1,
+               next_probe_at = NOW() + ($2 || ' days')::interval, error_message = $3
+           WHERE domain = $1`,
+          [c.domain, FAILED_RETRY_DAYS, String(e?.message || e).slice(0, 500)],
+        );
+        failed++;
+        return;
+      }
+
+      if (!p.reached) {
+        await updateWithRetry(
+          `UPDATE publisher_discovery
+           SET status = 'failed', retry_count = retry_count + 1,
+               next_probe_at = NOW() + ($2 || ' days')::interval, error_message = 'unreachable'
+           WHERE domain = $1`,
+          [c.domain, FAILED_RETRY_DAYS],
+        );
+        failed++;
+        return;
+      }
+
+      await updateWithRetry(
+        `UPDATE publisher_discovery
+         SET status = 'probed', probed_at = NOW(), error_message = NULL,
+             ads_txt_valid = $2, http_status = $3,
+             is_japanese = $4, jp_method = $5, jp_confidence = $6, jp_char_ratio = $7
+         WHERE domain = $1`,
+        [c.domain, p.adsTxtValid, p.httpStatus, p.jp.isJapanese, p.jp.method, p.jp.confidence, p.jp.charRatio],
+      );
+      probed++;
+      if (p.jp.isJapanese && p.adsTxtValid) jpValid++;
+    } catch {
+      // DB write still failing after retries — leave the row pending and move on.
+      skipped++;
+    }
+  });
+
+  if (skipped) console.warn(`Skipped ${skipped} row(s) after DB write failures (left pending).`);
+  return { probed, jpValid, failed };
+}

--- a/backend/src/discovery/runner.ts
+++ b/backend/src/discovery/runner.ts
@@ -1,0 +1,89 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.join(__dirname, '../../.env') });
+
+import { pool, query } from '../db/client';
+import { generateCandidates } from './candidate_generator';
+import { probePending } from './prober';
+import { enroll } from './enroller';
+
+/**
+ * Publisher discovery runner.
+ *
+ *   ts-node src/discovery/runner.ts refresh
+ *   ts-node src/discovery/runner.ts probe   [--limit 2000] [--concurrency 20]
+ *   ts-node src/discovery/runner.ts enroll  [--max 1000] [--wave1]
+ *   ts-node src/discovery/runner.ts stats
+ *
+ * Recommended first wave (report-safe, ~10% of current base):
+ *   refresh -> probe --limit 20000 -> enroll --max 1000 --wave1
+ */
+
+function flag(name: string, def: number): number {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i === -1) return def;
+  const v = Number(process.argv[i + 1]);
+  return Number.isFinite(v) ? v : def;
+}
+
+function has(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+async function printStats() {
+  const s = await query(
+    `SELECT status, count(*) n,
+            count(*) FILTER (WHERE is_japanese) jp,
+            count(*) FILTER (WHERE is_japanese AND ads_txt_valid) jp_valid
+     FROM publisher_discovery GROUP BY status ORDER BY status`,
+  );
+  console.table(s.rows);
+  const src = await query(
+    `SELECT source, count(*) n FROM monitored_domains WHERE file_type='ads.txt' GROUP BY source ORDER BY n DESC`,
+  );
+  console.log('monitored_domains(ads.txt) by source:');
+  console.table(src.rows);
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  switch (cmd) {
+    case 'refresh': {
+      console.time('refresh');
+      const r = await generateCandidates();
+      console.timeEnd('refresh');
+      console.log(`Candidates: scanned ${r.scanned} distinct domains, inserted ${r.inserted} new pending rows.`);
+      break;
+    }
+    case 'probe': {
+      const limit = flag('limit', 2000);
+      const concurrency = flag('concurrency', 20);
+      console.time('probe');
+      const r = await probePending(limit, concurrency);
+      console.timeEnd('probe');
+      console.log(`Probed ${r.probed} (JP & valid: ${r.jpValid}), failed/unreachable: ${r.failed}.`);
+      break;
+    }
+    case 'enroll': {
+      const max = flag('max', 1000);
+      const wave1 = has('wave1');
+      const r = await enroll({ max, highConfidenceOnly: wave1 });
+      console.log(`Enrolled ${r.enrolled} domain(s) into monitored_domains (source=discovery). Rejected ${r.rejected}.`);
+      break;
+    }
+    case 'stats':
+      await printStats();
+      break;
+    default:
+      console.error('Usage: runner.ts <refresh|probe|enroll|stats> [options]');
+      process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('discovery runner failed:', e);
+    process.exitCode = 1;
+  })
+  .finally(() => pool.end());

--- a/backend/src/discovery/util.ts
+++ b/backend/src/discovery/util.ts
@@ -1,0 +1,43 @@
+import psl from 'psl';
+
+const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*\.[a-z]{2,}$/;
+
+/**
+ * Normalize a raw seller_domain to its registrable root (e.g. www.sub.example.com ->
+ * example.com), matching how ssp-inventory treats domains. Returns null for invalid or
+ * non-registrable inputs. `.jp` is intentionally excluded upstream, but we also drop it
+ * here as a safety net.
+ */
+export function toRootDomain(input: string): string | null {
+  const raw = input.trim().toLowerCase().replace(/^https?:\/\//, '').split('/')[0].replace(/:\d+$/, '');
+  if (!raw || !raw.includes('.')) return null;
+  if (raw.endsWith('.jp')) return null;
+  const root = psl.get(raw);
+  if (!root) return null;
+  return DOMAIN_RE.test(root) ? root : null;
+}
+
+/** Run `worker` over `items` with a bounded number of concurrent executions. */
+export async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function run(): Promise<void> {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      results[idx] = await worker(items[idx]);
+    }
+  }
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, run);
+  await Promise.all(runners);
+  return results;
+}
+
+export function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}

--- a/backend/src/services/monitored_domains.ts
+++ b/backend/src/services/monitored_domains.ts
@@ -89,6 +89,7 @@ export class MonitoredDomainsService {
   async bulkAddDomains(
     domains: string[],
     fileType: 'ads.txt' | 'app-ads.txt' | 'sellers.json' = 'ads.txt',
+    source = 'organic',
   ): Promise<{ added: number; total: number }> {
     if (domains.length === 0) return { added: 0, total: 0 };
 
@@ -97,11 +98,11 @@ export class MonitoredDomainsService {
 
     // Batch insert using UNNEST for PostgreSQL
     const res = await query(
-      `INSERT INTO monitored_domains (domain, file_type, scan_interval_minutes, next_scan_at)
-       SELECT unnest($1::text[]), $2, 20160, NOW() + ((20160 * random()) || ' minutes')::interval
+      `INSERT INTO monitored_domains (domain, file_type, scan_interval_minutes, next_scan_at, source)
+       SELECT unnest($1::text[]), $2, 20160, NOW() + ((20160 * random()) || ' minutes')::interval, $3
        ON CONFLICT (domain, file_type) DO UPDATE SET is_active = true
        RETURNING domain`,
-      [unique, fileType],
+      [unique, fileType, source],
     );
 
     return { added: res.rows.length, total: unique.length };


### PR DESCRIPTION
## What & why

Automates the previously-manual **`jp_publisher_extractor` CSV → bulk-import** loop as a first-class pipeline. It finds publisher domains referenced in `sellers_catalog` that we do **not** yet crawl, probes their `ads.txt` and detects Japanese content, and enrolls the qualifying ones into `monitored_domains` (tagged `source='discovery'`).

Only ~3.3% of the ~338k publisher domains referenced in sellers.json are currently crawled. `.jp` is already covered by a separate crawler, so this targets **gTLD (mainly .com) Japanese publishers**, which are identifiable only by page **content**, not TLD.

## What's included

- **migration** `20260725_publisher_discovery.sql`: `publisher_discovery` table + `monitored_domains.source` column (default `organic`, so monthly reports can segment organic vs discovery cohorts).
- **`lang_detector.ts`**: dependency-free multi-dimensional JP detection ported from the Python tool (`<html lang>`, `og:locale`, `Content-Language`, kana density). Kana is scored separately from kanji so Chinese pages aren't misclassified. 7 unit tests.
- **`candidate_generator` / `prober` / `enroller` / `runner`** (`npm run discovery`).
- Prober is **resilient to transient DB drops** (in-flight rows stay `pending`, batch continues) with capped per-write retries.
- Enroller **throttles via `--max`** and tags `source='discovery'` for report safety.
- **`.github/workflows/deploy-discovery-job.yml`**: Cloud Run Job to run the crawl in GCP (Cloud SQL Unix socket, GCP DNS, `UV_THREADPOOL_SIZE=64`) — see `src/discovery/README.md`.

## Live status (already applied to the DB)

- Migration applied; candidate queue populated (~307k).
- **Wave 1 + wave 2 enrolled: 504 discovery domains** now crawling (447 `html_lang`, 57 widened incl. kana/og/content-language), tagged `source='discovery'`, jitter-scheduled — no scan storm, ~+4.5% over the organic base.
- Remaining ~293k candidates are `pending`; bulk probing should run via the Cloud Run Job (local sandbox hit hourly proxy-token expiry + DNS rate-limiting — env issues, not the pipeline; probe1 cleanly did 12,700 domains → 461 JP-valid).

## Verification

- `tsc --noEmit` clean; `npm run build` emits `dist/discovery/*`; `jest` 7/7 on the detector.