### PR TITLE
fix(discovery): cap retries and probe fresh candidates first

### DIFF
--- a/backend/src/discovery/README.md
+++ b/backend/src/discovery/README.md
@@ -19,6 +19,15 @@ not by TLD. Candidate generation excludes `*.jp`.
 | probe | `prober.ts` | Fetch `ads.txt` (validate the `(ssp, seller_id)` relationship) + fetch homepage → `services/language_detector.ts`. Writes verdict for **every** candidate (JP and non-JP). |
 | enroll | `enroller.ts` | JP + ads.txt-valid → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Non-JP / invalid probed rows → `rejected`. |
 
+Statuses: `pending` → `probed` → `enrolled` / `rejected`; unreachable candidates go
+`failed` (retried after 3 days) and then `dead` once they exhaust `MAX_RETRIES`. Probing
+takes never-tried candidates first (`ORDER BY retry_count, queued_at`), so a batch is spent
+on fresh domains rather than grinding the dead tail.
+
+The sellers.json universe carries a large tail of long-dead publisher domains — measured on
+the live queue, 39 of 40 hosts that failed to resolve also failed from a second network. The
+retry cap keeps them from cycling through every retry window forever.
+
 Language detection reuses the shared `services/language_detector.ts`
 (`detectLanguageFromHtml`), which weighs actual page script (kana) **above** declared
 metadata. That ordering is essential here: many Japanese publishers on gTLDs ship a

--- a/backend/src/discovery/prober.ts
+++ b/backend/src/discovery/prober.ts
@@ -7,6 +7,27 @@ import { mapPool } from './util';
 const REQUEST_TIMEOUT = 12000;
 const FAILED_RETRY_DAYS = 3;
 
+/**
+ * Attempts a candidate gets before it is written off as 'dead'. Measured against the
+ * live queue: of hosts that failed to resolve, 39/40 also failed from a second network,
+ * i.e. they are genuinely gone rather than transiently unreachable.
+ */
+const MAX_RETRIES = 2;
+
+/**
+ * Record a failed attempt. The row is retired to 'dead' on the attempt that exhausts its
+ * budget, rather than lingering as 'failed' until some later run notices — that keeps the
+ * queue honest even if no further batch ever runs.
+ */
+const FAIL_SQL = `
+  UPDATE publisher_discovery
+  SET retry_count = retry_count + 1,
+      status = CASE WHEN retry_count + 1 >= $4 THEN 'dead' ELSE 'failed' END,
+      next_probe_at = CASE WHEN retry_count + 1 >= $4 THEN NULL
+                           ELSE NOW() + ($2 || ' days')::interval END,
+      error_message = $3
+  WHERE domain = $1`;
+
 /** Run a write, retrying a few times on connection-level failures (proxy blips). */
 async function updateWithRetry(sql: string, params: any[], attempts = 4): Promise<void> {
   for (let i = 1; i <= attempts; i++) {
@@ -134,12 +155,24 @@ export async function probePending(
   limit: number,
   concurrency = 20,
 ): Promise<{ probed: number; jpValid: number; failed: number }> {
+  // Retire candidates that have burned through their retry budget before selecting work,
+  // so a batch is never spent re-probing domains that are simply gone. The sellers.json
+  // universe contains a large tail of long-dead publisher domains; without this they
+  // would cycle through every retry window forever.
+  await query(
+    `UPDATE publisher_discovery SET status = 'dead'
+     WHERE status IN ('pending', 'failed') AND retry_count >= $1`,
+    [MAX_RETRIES],
+  );
+
+  // Never-tried candidates first: a fresh domain is far likelier to yield a verdict than
+  // one that already failed, so this keeps each batch's useful-work ratio high.
   const res = await query(
     `SELECT domain, discovered_ssp, seller_id
      FROM publisher_discovery
      WHERE status = 'pending'
         OR (status = 'failed' AND (next_probe_at IS NULL OR next_probe_at <= NOW()))
-     ORDER BY queued_at
+     ORDER BY retry_count, queued_at
      LIMIT $1`,
     [limit],
   );
@@ -161,25 +194,18 @@ export async function probePending(
       try {
         p = await probeOne(c);
       } catch (e: any) {
-        await updateWithRetry(
-          `UPDATE publisher_discovery
-           SET status = 'failed', retry_count = retry_count + 1,
-               next_probe_at = NOW() + ($2 || ' days')::interval, error_message = $3
-           WHERE domain = $1`,
-          [c.domain, FAILED_RETRY_DAYS, String(e?.message || e).slice(0, 500)],
-        );
+        await updateWithRetry(FAIL_SQL, [
+          c.domain,
+          FAILED_RETRY_DAYS,
+          String(e?.message || e).slice(0, 500),
+          MAX_RETRIES,
+        ]);
         failed++;
         return;
       }
 
       if (!p.reached) {
-        await updateWithRetry(
-          `UPDATE publisher_discovery
-           SET status = 'failed', retry_count = retry_count + 1,
-               next_probe_at = NOW() + ($2 || ' days')::interval, error_message = 'unreachable'
-           WHERE domain = $1`,
-          [c.domain, FAILED_RETRY_DAYS],
-        );
+        await updateWithRetry(FAIL_SQL, [c.domain, FAILED_RETRY_DAYS, 'unreachable', MAX_RETRIES]);
         failed++;
         return;
       }


### PR DESCRIPTION
## What the canary showed

The first Cloud Run Job execution succeeded end-to-end — image build, job deploy, Cloud SQL over the Unix socket, DB writes, `exit(0)`. **The GCP infrastructure is validated.**

But it probed only 169 domains against 1,831 unreachable. That is **not** an infrastructure fault:

- Of 40 hosts GCP reported `ENOTFOUND`, **39 also failed to resolve from a second network** — they are genuinely gone.
- Log breakdown: 347 `ENOTFOUND` vs 38 `EAI_AGAIN`, i.e. overwhelmingly hard NXDOMAIN rather than resolver strain.

The sellers.json universe simply carries a long tail of dead publisher domains.

## Why that tail was expensive

1. **No retry cap** — a dead domain re-entered the queue every 3 days, forever.
2. **`ORDER BY queued_at` alone** put the ~40k previously-failed rows (which retain their original `queued_at`) at the head of the queue, so the canary spent its entire batch on them.

Queue state confirming this: of 291,070 pending, **40,117 carry `retry_count > 0`** (38,275 at 1, 557 at 2, 1,285 at 3).

## Fixes

- `MAX_RETRIES = 2`. A row is retired to `'dead'` in the same `UPDATE` that exhausts its budget, so the queue stays correct even if no later batch runs. A sweep also retires rows already over budget (~1,842 immediately).
- `ORDER BY retry_count, queued_at` — never-tried candidates first. The next batch therefore draws from the ~250k fresh candidates rather than the dead tail; the 38,275 at `retry_count=1` still get their one remaining attempt, but last.

## Verification

CASE semantics checked against Postgres in a rolled-back transaction (production untouched):

| before | after | status | retry date |
|---|---|---|---|
| 0 | 1 | `failed` | set |
| 1 | 2 | `dead` | cleared |
| 2 | 3 | `dead` | cleared |

`tsc --noEmit` clean, `npm run build` clean, **67/67 tests pass**.

## Note on an earlier mistake of mine

The 40,117 rows carrying `retry_count > 0` are there because I earlier reset that many "false failures" wholesale during a window when the local resolver was throttled. Most of them were in fact genuinely dead; I could not distinguish the two at the time and over-corrected. This change makes that self-limiting rather than permanent.