### PR TITLE
perf(scanner): scan monitored domains concurrently and raise the batch

### DIFF
--- a/backend/src/discovery/util.ts
+++ b/backend/src/discovery/util.ts
@@ -1,5 +1,7 @@
 import psl from 'psl';
 
+export { mapPool } from '../lib/concurrency';
+
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*\.[a-z]{2,}$/;
 
 /**
@@ -15,25 +17,6 @@ export function toRootDomain(input: string): string | null {
   const root = psl.get(raw);
   if (!root) return null;
   return DOMAIN_RE.test(root) ? root : null;
-}
-
-/** Run `worker` over `items` with a bounded number of concurrent executions. */
-export async function mapPool<T, R>(
-  items: T[],
-  concurrency: number,
-  worker: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let cursor = 0;
-  async function run(): Promise<void> {
-    while (cursor < items.length) {
-      const idx = cursor++;
-      results[idx] = await worker(items[idx]);
-    }
-  }
-  const runners = Array.from({ length: Math.min(concurrency, items.length) }, run);
-  await Promise.all(runners);
-  return results;
 }
 
 export function chunk<T>(arr: T[], size: number): T[][] {

--- a/backend/src/jobs/scheduler.ts
+++ b/backend/src/jobs/scheduler.ts
@@ -7,9 +7,17 @@ import { LanguageDetector } from '../services/language_detector';
 import { MonitoredDomainsService } from '../services/monitored_domains';
 
 import { runCleanup } from './cleanup';
+import { mapPool } from '../lib/concurrency';
 
 const monitoredDomainsService = new MonitoredDomainsService();
 const scanner = new AdsTxtScanner();
+
+// Scan throughput. The previous sequential loop managed ~50 domains per run at ~6s each
+// (a 1s politeness sleep plus two HTTP fetches), which could not keep a growing monitored
+// set inside its 14-day cycle. Distinct hosts are fetched concurrently instead; the
+// politeness sleep is dropped because consecutive items are different domains.
+const SCAN_BATCH_SIZE = Number(process.env.SCAN_BATCH_SIZE ?? 200);
+const SCAN_CONCURRENCY = Number(process.env.SCAN_CONCURRENCY ?? 8);
 const languageDetector = new LanguageDetector();
 
 // 処理中のロック（簡易版）
@@ -76,48 +84,65 @@ export function setupCronJobs() {
  */
 export async function processMonitoredDomains() {
   console.log('Checking for monitored domains due for scan...');
-  const dueDomains = await monitoredDomainsService.getDueDomains();
+  const dueDomains = await monitoredDomainsService.getDueDomains(SCAN_BATCH_SIZE);
   console.log(`Found ${dueDomains.length} domains due for ads.txt scan.`);
 
   const importer = new StreamImporter();
 
-  for (const item of dueDomains) {
+  // ads.txt/app-ads.txt fetches are independent hosts, so they run concurrently.
+  // sellers.json stays sequential: those files are frequently hundreds of MB and
+  // streaming several at once would blow up memory.
+  const fileScans = dueDomains.filter(
+    (d): d is typeof d & { file_type: 'ads.txt' | 'app-ads.txt' } => d.file_type !== 'sellers.json',
+  );
+  const sellersScans = dueDomains.filter((d) => d.file_type === 'sellers.json');
+
+  const started = Date.now();
+
+  await mapPool(fileScans, SCAN_CONCURRENCY, async (item) => {
+    try {
+      const result = await scanner.scanAndSave(item.domain, item.file_type);
+      console.log(`Scan completed for ${item.domain} (${item.file_type}, ID: ${result.id})`);
+
+      // Piggyback content-language detection on the scan (no-op if a fresh result exists)
+      const lang = await languageDetector.detectIfDue(item.domain);
+      if (lang) {
+        console.log(
+          `Language detected for ${item.domain}: ${lang.content_lang ?? 'unknown'} (${lang.lang_source ?? 'n/a'})`,
+        );
+      }
+      await monitoredDomainsService.updateLastScanned(item.domain, item.file_type);
+    } catch (e: any) {
+      console.error(`Failed to scan ${item.domain} (${item.file_type}): ${e.message}`);
+      // Still reschedule, so one bad domain cannot block the queue forever.
+      await monitoredDomainsService.updateLastScanned(item.domain, item.file_type);
+    }
+  });
+
+  for (const item of sellersScans) {
     console.log(`Scanning ${item.file_type} for monitored domain: ${item.domain}`);
     try {
-      if (item.file_type === 'sellers.json') {
-        let url = `https://${item.domain}/sellers.json`;
-        if (item.domain in SPECIAL_DOMAINS) {
-          url = SPECIAL_DOMAINS[item.domain];
-        }
-
-        await importer.importSellersJson({ domain: item.domain, url });
-        console.log(`Sellers.json import completed for ${item.domain}`);
-
-        // Wait a bit
-        await new Promise((r) => setTimeout(r, 1000));
-      } else {
-        // ads.txt or app-ads.txt
-        const result = await scanner.scanAndSave(item.domain, item.file_type);
-        console.log(`Scan completed for ${item.domain} (${item.file_type}, ID: ${result.id})`);
-
-        // Piggyback content-language detection on the scan (no-op if a fresh result exists)
-        const lang = await languageDetector.detectIfDue(item.domain);
-        if (lang) {
-          console.log(
-            `Language detected for ${item.domain}: ${lang.content_lang ?? 'unknown'} (${lang.lang_source ?? 'n/a'})`,
-          );
-        }
+      let url = `https://${item.domain}/sellers.json`;
+      if (item.domain in SPECIAL_DOMAINS) {
+        url = SPECIAL_DOMAINS[item.domain];
       }
+
+      await importer.importSellersJson({ domain: item.domain, url });
+      console.log(`Sellers.json import completed for ${item.domain}`);
 
       await monitoredDomainsService.updateLastScanned(item.domain, item.file_type);
 
-      // Wait to be polite
-      if (item.file_type !== 'sellers.json') await new Promise((r) => setTimeout(r, 1000));
+      // Wait a bit
+      await new Promise((r) => setTimeout(r, 1000));
     } catch (e: any) {
       console.error(`Failed to scan ${item.domain} (${item.file_type}): ${e.message}`);
       await monitoredDomainsService.updateLastScanned(item.domain, item.file_type);
     }
   }
+
+  console.log(
+    `Scanned ${fileScans.length} file(s) + ${sellersScans.length} sellers.json in ${Math.round((Date.now() - started) / 1000)}s`,
+  );
 
   // StreamImporter creates a connection pool in its constructor; close it when done.
   await importer.close();

--- a/backend/src/lib/concurrency.ts
+++ b/backend/src/lib/concurrency.ts
@@ -1,0 +1,18 @@
+/** Run `worker` over `items` with a bounded number of concurrent executions. */
+export async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function run(): Promise<void> {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      results[idx] = await worker(items[idx]);
+    }
+  }
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, run);
+  await Promise.all(runners);
+  return results;
+}


### PR DESCRIPTION
## The problem

The monitored-domain scanner cannot keep its own 14-day cycle. Measured on production:

| | |
|---|---|
| Scans achieved | **~400/day** |
| Scans required (12,491 domains / 14 days) | **892/day** |
| Domains already overdue | **1,549** |
| Of 1,061 domains enrolled 2026-07-27, scanned 4 days later | **182 (17%)** |

So enrolling more domains currently produces no result — they simply queue up unscanned, and `ssp-inventory` coverage never resolves from `unknown`.

## Diagnosis

From the scan timestamps, there are two independent causes:

1. **Per-run cost.** Each run processed exactly 50 domains (the default `getDueDomains` limit) at a **median 6.1s each** — a 1s politeness sleep plus two HTTP fetches (ads.txt, then the homepage for language detection), all sequential. ~305s per run.
2. **Run frequency.** Bursts of 50 appear roughly every **2.5–3.5 hours**, not the configured 15 minutes — consistent with the note already in `scheduler.ts` that node-cron is unreliable on Cloud Run.

`8 runs/day × 50 = ~400/day`, which matches the observation exactly.

## This PR: the per-run cost

- ads.txt / app-ads.txt fetches run through a bounded pool — `SCAN_CONCURRENCY` (default 8).
- Batch size is configurable — `SCAN_BATCH_SIZE` (default 200, was a hardcoded 50).
- The 1s politeness sleep is dropped: consecutive items are always *different* hosts, so it bought nothing.
- `sellers.json` imports stay **sequential** — those files are frequently hundreds of MB and streaming several concurrently would blow up memory.
- A failed scan still reschedules, so one bad domain cannot wedge the queue.

`mapPool` moved to `lib/concurrency.ts` so both the scanner and the discovery pipeline share it.

## Measured result

Run against production: **40 domains in 62s (1.55s each)**, versus 6.1s each sequentially — a **~4x improvement**. That alone lifts throughput to ~1,600/day even at the current unreliable trigger rate.

## Still needed: run frequency

Fixing frequency is infrastructure, not code. Adding a Cloud Scheduler trigger against `/api/jobs/scan` (which the code comment already recommends) brings capacity to 96 runs/day × 200 = 19,200/day, far above the ~1,639/day that the expanded monitored set will need:

```bash
BACKEND_URL=$(gcloud run services describe ttkit-backend --region asia-northeast1 --project apti-ttkit --format='value(status.url)')
gcloud scheduler jobs create http ttkit-scan-every-15min --location=asia-northeast1 --project=apti-ttkit --schedule="*/15 * * * *" --time-zone="Asia/Tokyo" --uri="${BACKEND_URL}/api/jobs/scan" --http-method=POST --attempt-deadline=600s --max-retry-attempts=0
```

`/api/jobs/*` is not behind `apiKeyAuth` (that middleware covers `/v1/*` only) and the service is deployed `--allow-unauthenticated`, so the scheduler needs no credentials — worth being aware of, since it also means anyone can trigger the job.

## Verification

`tsc --noEmit` clean, **67/67 tests pass**, plus the live 40-domain timing above.