### PR TITLE
feat(discovery): include .jp, and treat .jp registration as sufficient

### DIFF
--- a/backend/src/discovery/README.md
+++ b/backend/src/discovery/README.md
@@ -5,11 +5,20 @@ publisher domains referenced in `sellers_catalog` that we do **not** yet crawl, 
 their `ads.txt` and detects Japanese content, and enrolls qualifying domains into
 `monitored_domains` (tagged `source='discovery'`).
 
-## Why gTLD-focused
+## What counts as Japanese inventory
 
-`.jp` ccTLD publishers are already covered by a separate crawler, so this pipeline targets
-**gTLD (mainly `.com`) Japanese publishers**, which are only identifiable by page content —
-not by TLD. Candidate generation excludes `*.jp`.
+Two different signals, because the market is what matters — not the page language:
+
+- **`.jp` registration is sufficient on its own.** `japantimes.co.jp` publishes in English
+  for residents of Japan and carries Japanese advertisers' spend; gating it on kana would
+  drop it. Language is still detected and stored, just not used as a gate.
+- **Every other TLD is decided by page content**, since the TLD carries no signal. This is
+  where the bulk of the work is: Japanese publishers on `.com` are invisible to any
+  TLD-based rule.
+
+This pipeline originally excluded `.jp` because a separate crawler covered it. That
+separation is no longer needed — one pipeline now handles both, so discovery logic is not
+maintained twice and the `source` tag stops being a proxy for "which crawler found it".
 
 ## Pipeline
 
@@ -17,7 +26,7 @@ not by TLD. Candidate generation excludes `*.jp`.
 |---|---|---|
 | refresh | `candidate_generator.ts` | `sellers_catalog` − `monitored_domains` − queued → `publisher_discovery` (pending). Domains normalized to registrable root via `psl`. |
 | probe | `prober.ts` | Fetch `ads.txt` (validate the `(ssp, seller_id)` relationship) + fetch homepage → `services/language_detector.ts`. Writes verdict for **every** candidate (JP and non-JP). |
-| enroll | `enroller.ts` | JP + ads.txt-valid → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Non-JP / invalid probed rows → `rejected`. |
+| enroll | `enroller.ts` | Japanese inventory (`.jp` **or** JP content) + ads.txt-valid → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Everything else probed → `rejected`. |
 
 Statuses: `pending` → `probed` → `enrolled` / `rejected`; unreachable candidates go
 `failed` (retried after 3 days) and then `dead` once they exhaust `MAX_RETRIES`. Probing

--- a/backend/src/discovery/candidate_generator.ts
+++ b/backend/src/discovery/candidate_generator.ts
@@ -9,7 +9,6 @@ const INSERT_CHUNK = 5000;
  *
  * Filters:
  *   - seller_type PUBLISHER/BOTH (actual publishers, not pure intermediaries)
- *   - NOT `.jp` (handled by a separate crawler)
  *   - not already in monitored_domains (ads.txt)
  *   - not already queued in publisher_discovery
  *
@@ -26,7 +25,6 @@ export async function generateCandidates(): Promise<{ scanned: number; inserted:
      FROM sellers_catalog
      WHERE seller_domain LIKE '%.%'
        AND seller_domain NOT LIKE '% %'
-       AND seller_domain NOT LIKE '%.jp'
        AND seller_type IN ('PUBLISHER', 'BOTH')
      ORDER BY lower(seller_domain)`,
   );

--- a/backend/src/discovery/enroller.ts
+++ b/backend/src/discovery/enroller.ts
@@ -18,19 +18,32 @@ export interface EnrollOptions {
 const HIGH_CONFIDENCE = 0.9;
 
 /**
- * Enroll probed, Japanese, ads.txt-valid candidates into monitored_domains (tagged
+ * Qualifies as Japanese inventory.
+ *
+ * A `.jp` registration is sufficient on its own — the market, not the page language, is
+ * what makes inventory Japanese. japantimes.co.jp publishes in English for residents of
+ * Japan and carries Japanese advertisers' spend; gating it on kana would drop it. For
+ * every other TLD there is no such signal, so content detection decides.
+ */
+const IS_JP_INVENTORY = `(domain LIKE '%.jp' OR is_japanese = true)`;
+
+/**
+ * Enroll probed, ads.txt-valid Japanese inventory into monitored_domains (tagged
  * source='discovery'), then mark the rest of the probed batch as rejected so they are
  * not re-probed.
  */
 export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; rejected: number }> {
-  const confFilter = opts.highConfidenceOnly ? `AND jp_confidence >= ${HIGH_CONFIDENCE}` : '';
+  // `.jp` counts as hard evidence too, so it is never held back by the conservative wave.
+  const confFilter = opts.highConfidenceOnly
+    ? `AND (jp_confidence >= ${HIGH_CONFIDENCE} OR domain LIKE '%.jp')`
+    : '';
 
   const res = await query(
     `SELECT domain
      FROM publisher_discovery
-     WHERE status = 'probed' AND is_japanese = true AND ads_txt_valid = true
+     WHERE status = 'probed' AND ads_txt_valid = true AND ${IS_JP_INVENTORY}
      ${confFilter}
-     ORDER BY jp_confidence DESC
+     ORDER BY jp_confidence DESC NULLS LAST
      LIMIT $1`,
     [opts.max],
   );
@@ -47,11 +60,13 @@ export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; r
     enrolled = upd.rows.length;
   }
 
-  // Retire probed candidates that will never be enrolled (not JP, or ads.txt invalid)
-  // so future probe passes skip them.
+  // Retire probed candidates that will never be enrolled (not Japanese inventory, or
+  // ads.txt invalid) so future probe passes skip them. This must use the same predicate
+  // as the selection above, or an English-language `.jp` site would be rejected here
+  // instead of waiting for the next batch.
   const rej = await query(
     `UPDATE publisher_discovery SET status = 'rejected'
-     WHERE status = 'probed' AND (is_japanese = false OR ads_txt_valid = false)
+     WHERE status = 'probed' AND (NOT ${IS_JP_INVENTORY} OR ads_txt_valid = false)
      RETURNING domain`,
   );
 

--- a/backend/src/discovery/util.ts
+++ b/backend/src/discovery/util.ts
@@ -7,13 +7,11 @@ const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61
 /**
  * Normalize a raw seller_domain to its registrable root (e.g. www.sub.example.com ->
  * example.com), matching how ssp-inventory treats domains. Returns null for invalid or
- * non-registrable inputs. `.jp` is intentionally excluded upstream, but we also drop it
- * here as a safety net.
+ * non-registrable inputs.
  */
 export function toRootDomain(input: string): string | null {
   const raw = input.trim().toLowerCase().replace(/^https?:\/\//, '').split('/')[0].replace(/:\d+$/, '');
   if (!raw || !raw.includes('.')) return null;
-  if (raw.endsWith('.jp')) return null;
   const root = psl.get(raw);
   if (!root) return null;
   return DOMAIN_RE.test(root) ? root : null;


### PR DESCRIPTION
## Why

The pipeline excluded `.jp` because a separate crawler covered it. That crawler is no longer needed now that discovery does the same job, so the exclusion only leaves domains uncrawled and keeps two discovery paths in maintenance.

Current gap:

| | |
|---|---|
| `.jp` publisher domains in `sellers_catalog` | 8,889 |
| **not yet monitored** | **6,159** |
| not in the discovery queue (excluded by design) | 8,888 |

It also makes the `source` tag honest. Today `discovery` is 100% non-`.jp` and `organic` is 90% `.jp` — the tag has been recording *which crawler found it*, not anything about the domain.

## The definitional change

Enrollment now qualifies a candidate as Japanese inventory when it is **either** a `.jp` registration **or** detected Japanese content:

```sql
(domain LIKE '%.jp' OR is_japanese = true)
```

`.jp` is sufficient on its own because the *market* is what makes inventory Japanese, not the page language. `japantimes.co.jp` publishes in English for residents of Japan and carries Japanese advertisers' spend; gating it on kana would drop it. Language is still detected and stored for `.jp` domains — it is simply not a gate.

For every other TLD nothing changes: content decides, since the TLD carries no signal.

The `--wave1` conservative filter also accepts `.jp`, since a `.jp` registration is at least as hard a signal as kana detection.

## Correctness detail

The rejection sweep had to change too. It previously retired `is_japanese = false` rows, which would have marked an English-language `.jp` site as `rejected` rather than leaving it for the next batch. Both queries now share one predicate.

Verified against Postgres in a rolled-back transaction:

| domain | is_japanese | ads_txt_valid | enroll | reject |
|---|---|---|---|---|
| japantimes.co.jp | false | true | ✅ | — |
| example.co.jp | true | true | ✅ | — |
| blog.com | true | true | ✅ | — |
| foo.com | false | true | — | ✅ |
| bar.co.jp | true | false | — | ✅ |

Mutually exclusive and exhaustive.

## Rollout after merge

`refresh` → `probe` → `enroll`. The ~6,159 `.jp` candidates enter the existing queue; probe capacity is 10,000/hour, so this is well under an hour of work. Scan capacity is ~19,200/day against ~1,687/day currently needed, so the additional domains are comfortably absorbed.

The separate `.jp` crawler can be retired once this lands; running both is harmless in the meantime (`ON CONFLICT` makes double enrollment a no-op).

## Verification

`tsc --noEmit` clean, **67/67 tests pass**.