### PR TITLE
fix(discovery): cap probe response size to stop the job running out of memory

### DIFF
--- a/.github/workflows/deploy-discovery-job.yml
+++ b/.github/workflows/deploy-discovery-job.yml
@@ -78,7 +78,7 @@ jobs:
             --set-env-vars DATABASE_URL="postgres://postgres:${{ secrets.DB_PASSWORD }}@/${{ secrets.DB_NAME }}?host=/cloudsql/${DB_CONNECTION_NAME}",UV_THREADPOOL_SIZE=64 \
             --task-timeout=3600 \
             --max-retries=1 \
-            --memory=1Gi \
+            --memory=2Gi \
             --cpu=1
 
       - name: Execute once

--- a/backend/src/discovery/prober.ts
+++ b/backend/src/discovery/prober.ts
@@ -5,6 +5,8 @@ import { detectLanguageFromHtml } from '../services/language_detector';
 import { mapPool } from './util';
 
 const REQUEST_TIMEOUT = 12000;
+/** Largest response body to buffer per request; see the note in fetchUrl. */
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const FAILED_RETRY_DAYS = 3;
 
 /**
@@ -63,6 +65,13 @@ async function fetchUrl(url: string): Promise<FetchResult | null> {
       responseType: 'text',
       maxRedirects: 5,
       validateStatus: () => true,
+      // Cap the body. Nothing this pipeline decides needs more than the head of a
+      // document — the language detector only reads the first 200k chars and ads.txt
+      // validation only needs the records — but without a cap, `concurrency` large
+      // responses are held in memory at once, which is what exhausted the heap when
+      // .jp portals entered the queue.
+      maxContentLength: MAX_RESPONSE_BYTES,
+      maxBodyLength: MAX_RESPONSE_BYTES,
       // Discovery probes millions of mostly-junk domains; the shared client's 3 retries
       // would dominate runtime on dead hosts. One retry is enough for transient blips.
       'axios-retry': { retries: 1 },


### PR DESCRIPTION
## What happened

The first `probe` run after `.jp` domains entered the queue (PR #22) failed:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
Container terminated on signal 11.
```

It died at ~507MB inside a 1Gi container.

## Cause

`fetchUrl` buffered whole response bodies with no size limit, so up to `concurrency` (40) large documents were resident at once. The gTLD population kept this small by accident — junk domains serve small pages. `.jp` portals do not.

## Fix

- **Cap bodies at 4MB** (`maxContentLength` / `maxBodyLength`). Nothing in this pipeline needs a whole document: the language detector reads only the first 200k chars, and ads.txt validation only needs the records. This bounds worst-case buffering to ~160MB at concurrency 40.
- **Job memory 1Gi → 2Gi** for headroom, since parsing a large ads.txt costs more than the raw body.

## Urgency

The **hourly scheduled probe** (`ttkit-discovery-probe-hourly`) now draws from a queue containing `.jp` candidates, so it is exposed to the same crash until this lands. Failures are not destructive — verdict writes are per-row, so each run keeps whatever it completed before dying — but the runs are wasteful. Pausing the schedule until merge is an option:

```bash
gcloud scheduler jobs pause ttkit-discovery-probe-hourly --location asia-northeast1 --project apti-ttkit
```

## Verification

`tsc --noEmit` clean, **67/67 tests pass**.