### PR TITLE
feat(discovery): enroll on ads.txt presence rather than a single SSP match

### DIFF
--- a/.github/workflows/deploy-discovery-job.yml
+++ b/.github/workflows/deploy-discovery-job.yml
@@ -14,7 +14,7 @@ on:
         description: "runner command"
         type: choice
         default: probe
-        options: [refresh, probe, enroll, reset-language-rejections, stats]
+        options: [refresh, probe, enroll, reset-language-rejections, requeue-adstxt-holders, stats]
       extra_args:
         description: "comma-separated args (e.g. --limit,20000,--concurrency,40 or --max,1000,--wave1)"
         default: "--limit,20000,--concurrency,40"

--- a/backend/src/db/migrations/20260801_add_ads_txt_records.sql
+++ b/backend/src/db/migrations/20260801_add_ads_txt_records.sql
@@ -1,0 +1,20 @@
+-- Record how many ads.txt records a candidate actually publishes.
+--
+-- Enrollment previously required ads_txt_valid — that the ads.txt declared the one
+-- (SSP, seller_id) pair the candidate happened to be generated from. That gate turned out
+-- to be the dominant constraint: of 765 .jp candidates serving a real ads.txt, only 161
+-- (21%) declared the specific SSP we checked, because Japanese publishers are typically
+-- listed by domestic SSPs whose sellers.json entries go stale.
+--
+-- The pipeline exists to widen ads.txt crawl coverage, so the criterion that matters is
+-- "publishes a real ads.txt", not "this particular seller relationship is still live".
+-- ads_txt_valid is still recorded — it remains a useful signal — it just no longer gates.
+
+ALTER TABLE publisher_discovery
+    ADD COLUMN IF NOT EXISTS ads_txt_records INT;
+
+COMMENT ON COLUMN publisher_discovery.ads_txt_records IS
+    'Number of parseable ads.txt records served by the domain. NULL = not measured (probed before this column existed). Enrollment requires >= 1.';
+
+CREATE INDEX IF NOT EXISTS idx_pd_enrollable_records
+    ON publisher_discovery (status, ads_txt_records);

--- a/backend/src/discovery/README.md
+++ b/backend/src/discovery/README.md
@@ -26,7 +26,16 @@ maintained twice and the `source` tag stops being a proxy for "which crawler fou
 |---|---|---|
 | refresh | `candidate_generator.ts` | `sellers_catalog` − `monitored_domains` − queued → `publisher_discovery` (pending). Domains normalized to registrable root via `psl`. |
 | probe | `prober.ts` | Fetch `ads.txt` (validate the `(ssp, seller_id)` relationship) + fetch homepage → `services/language_detector.ts`. Writes verdict for **every** candidate (JP and non-JP). |
-| enroll | `enroller.ts` | Japanese inventory (`.jp` **or** JP content) + ads.txt-valid → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Everything else probed → `rejected`. |
+| enroll | `enroller.ts` | Japanese inventory (`.jp` **or** JP content) that serves an ads.txt (`ads_txt_records >= 1`) → `bulkAddDomains(..., 'discovery')`, throttled by `--max`. Everything else probed → `rejected`. |
+
+Enrollment deliberately does **not** require `ads_txt_valid` — that the ads.txt declares
+the one `(SSP, seller_id)` pair the candidate was generated from. Measured on the live
+queue, that gate was the dominant constraint: of 765 `.jp` candidates serving a real
+ads.txt, only 161 (21%) declared the SSP we happened to check, because Japanese publishers
+are typically listed by domestic SSPs whose sellers.json entries go stale. The pipeline
+exists to widen ads.txt crawl coverage, so publishing an ads.txt is the criterion that
+matters; whether a given seller relationship is still live is visible from the crawled
+file. `ads_txt_valid` is still recorded as a signal.
 
 Statuses: `pending` → `probed` → `enrolled` / `rejected`; unreachable candidates go
 `failed` (retried after 3 days) and then `dead` once they exhaust `MAX_RETRIES`. Probing

--- a/backend/src/discovery/enroller.ts
+++ b/backend/src/discovery/enroller.ts
@@ -28,9 +28,22 @@ const HIGH_CONFIDENCE = 0.9;
 const IS_JP_INVENTORY = `(domain LIKE '%.jp' OR is_japanese = true)`;
 
 /**
- * Enroll probed, ads.txt-valid Japanese inventory into monitored_domains (tagged
- * source='discovery'), then mark the rest of the probed batch as rejected so they are
- * not re-probed.
+ * Publishes a real ads.txt.
+ *
+ * This replaced `ads_txt_valid` as the enrollment gate. Requiring the ads.txt to declare
+ * the one (SSP, seller_id) pair a candidate happened to be generated from turned out to be
+ * the dominant constraint: of 765 .jp candidates serving a real ads.txt, only 161 (21%)
+ * declared the SSP we happened to check, because Japanese publishers are typically listed
+ * by domestic SSPs whose sellers.json entries go stale. Since the pipeline exists to widen
+ * ads.txt crawl coverage, publishing an ads.txt at all is the criterion that matters;
+ * whether a given seller relationship is still live is visible from the crawled file.
+ */
+const HAS_ADS_TXT = `COALESCE(ads_txt_records, 0) >= 1`;
+
+/**
+ * Enroll probed Japanese inventory that publishes an ads.txt into monitored_domains
+ * (tagged source='discovery'), then mark the rest of the probed batch as rejected so they
+ * are not re-probed.
  */
 export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; rejected: number }> {
   // `.jp` counts as hard evidence too, so it is never held back by the conservative wave.
@@ -41,7 +54,7 @@ export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; r
   const res = await query(
     `SELECT domain
      FROM publisher_discovery
-     WHERE status = 'probed' AND ads_txt_valid = true AND ${IS_JP_INVENTORY}
+     WHERE status = 'probed' AND ${HAS_ADS_TXT} AND ${IS_JP_INVENTORY}
      ${confFilter}
      ORDER BY jp_confidence DESC NULLS LAST
      LIMIT $1`,
@@ -60,13 +73,13 @@ export async function enroll(opts: EnrollOptions): Promise<{ enrolled: number; r
     enrolled = upd.rows.length;
   }
 
-  // Retire probed candidates that will never be enrolled (not Japanese inventory, or
-  // ads.txt invalid) so future probe passes skip them. This must use the same predicate
-  // as the selection above, or an English-language `.jp` site would be rejected here
-  // instead of waiting for the next batch.
+  // Retire probed candidates that will never be enrolled (not Japanese inventory, or no
+  // ads.txt) so future probe passes skip them. This must be the exact negation of the
+  // selection above, or a qualifying row would be rejected here instead of waiting for
+  // the next batch.
   const rej = await query(
     `UPDATE publisher_discovery SET status = 'rejected'
-     WHERE status = 'probed' AND (NOT ${IS_JP_INVENTORY} OR ads_txt_valid = false)
+     WHERE status = 'probed' AND NOT (${HAS_ADS_TXT} AND ${IS_JP_INVENTORY})
      RETURNING domain`,
   );
 
@@ -85,6 +98,24 @@ export async function resetLanguageRejections(): Promise<{ requeued: number }> {
      SET status = 'pending', probed_at = NULL, error_message = NULL,
          is_japanese = NULL, jp_method = NULL, jp_confidence = NULL
      WHERE status = 'rejected' AND ads_txt_valid = true AND is_japanese = false
+     RETURNING domain`,
+  );
+  return { requeued: res.rows.length };
+}
+
+/**
+ * Re-queue candidates the old `ads_txt_valid` gate rejected even though they serve a live
+ * ads.txt. They need a re-probe rather than a plain status flip, because `ads_txt_records`
+ * did not exist when they were first measured.
+ */
+export async function requeueAdsTxtHolders(): Promise<{ requeued: number }> {
+  const res = await query(
+    `UPDATE publisher_discovery
+     SET status = 'pending', probed_at = NULL, error_message = NULL, retry_count = 0
+     WHERE status = 'rejected'
+       AND http_status = 200
+       AND ads_txt_records IS NULL
+       AND (domain LIKE '%.jp' OR is_japanese = true)
      RETURNING domain`,
   );
   return { requeued: res.rows.length };

--- a/backend/src/discovery/prober.ts
+++ b/backend/src/discovery/prober.ts
@@ -99,18 +99,33 @@ async function fetchFirst(urls: string[]): Promise<FetchResult | null> {
   return last;
 }
 
-/** Does the ads.txt content declare the (ssp, seller_id) relationship? */
-function adsTxtDeclares(content: string, domain: string, ssp: string | null, sellerId: string | null): boolean {
-  if (!ssp || !sellerId) return false;
+/**
+ * Parse an ads.txt once and report both how many records it publishes and whether it
+ * declares the (ssp, seller_id) pair this candidate was generated from.
+ *
+ * The record count is what gates enrollment; `declares` is kept as a signal because a
+ * candidate is generated from a single arbitrary pair, so a mismatch usually means the
+ * SSP's sellers.json is stale rather than that the domain is not a publisher.
+ */
+function inspectAdsTxt(
+  content: string,
+  domain: string,
+  ssp: string | null,
+  sellerId: string | null,
+): { records: number; declares: boolean } {
   const entries = parseAdsTxtContent(content, domain);
-  const wantSsp = ssp.trim().toLowerCase();
-  const wantId = sellerId.trim();
+  const wantSsp = ssp?.trim().toLowerCase();
+  const wantId = sellerId?.trim();
+  let records = 0;
+  let declares = false;
   for (const entry of entries) {
-    if (isAdsTxtRecord(entry) && entry.domain?.trim().toLowerCase() === wantSsp && entry.account_id?.trim() === wantId) {
-      return true;
+    if (!isAdsTxtRecord(entry)) continue;
+    records++;
+    if (wantSsp && wantId && entry.domain?.trim().toLowerCase() === wantSsp && entry.account_id?.trim() === wantId) {
+      declares = true;
     }
   }
-  return false;
+  return { records, declares };
 }
 
 interface JpVerdict {
@@ -121,6 +136,7 @@ interface JpVerdict {
 
 interface Probe {
   adsTxtValid: boolean;
+  adsTxtRecords: number | null;
   httpStatus: number | null;
   jp: JpVerdict;
   reached: boolean;
@@ -132,9 +148,12 @@ async function probeOne(c: Candidate): Promise<Probe> {
   // --- ads.txt ---
   const adsRes = await fetchFirst([`https://${c.domain}/ads.txt`, `http://${c.domain}/ads.txt`]);
   let adsTxtValid = false;
+  let adsTxtRecords: number | null = null;
   const httpStatus = adsRes?.status ?? null;
   if (adsRes && adsRes.status >= 200 && adsRes.status < 300 && adsRes.data && !adsRes.data.trimStart().startsWith('<')) {
-    adsTxtValid = adsTxtDeclares(adsRes.data, c.domain, c.discovered_ssp, c.seller_id);
+    const seen = inspectAdsTxt(adsRes.data, c.domain, c.discovered_ssp, c.seller_id);
+    adsTxtRecords = seen.records;
+    adsTxtValid = seen.declares;
   }
 
   // --- homepage / language detection ---
@@ -153,7 +172,7 @@ async function probeOne(c: Candidate): Promise<Probe> {
     };
   }
 
-  return { adsTxtValid, httpStatus, jp, reached: !!(adsRes || homeRes) };
+  return { adsTxtValid, adsTxtRecords, httpStatus, jp, reached: !!(adsRes || homeRes) };
 }
 
 /**
@@ -223,12 +242,12 @@ export async function probePending(
         `UPDATE publisher_discovery
          SET status = 'probed', probed_at = NOW(), error_message = NULL,
              ads_txt_valid = $2, http_status = $3,
-             is_japanese = $4, jp_method = $5, jp_confidence = $6
+             is_japanese = $4, jp_method = $5, jp_confidence = $6, ads_txt_records = $7
          WHERE domain = $1`,
-        [c.domain, p.adsTxtValid, p.httpStatus, p.jp.isJapanese, p.jp.method, p.jp.confidence],
+        [c.domain, p.adsTxtValid, p.httpStatus, p.jp.isJapanese, p.jp.method, p.jp.confidence, p.adsTxtRecords],
       );
       probed++;
-      if (p.jp.isJapanese && p.adsTxtValid) jpValid++;
+      if ((p.jp.isJapanese || c.domain.endsWith('.jp')) && (p.adsTxtRecords ?? 0) > 0) jpValid++;
     } catch {
       // DB write still failing after retries — leave the row pending and move on.
       skipped++;

--- a/backend/src/discovery/runner.ts
+++ b/backend/src/discovery/runner.ts
@@ -6,7 +6,7 @@ dotenv.config({ path: path.join(__dirname, '../../.env') });
 import { pool, query } from '../db/client';
 import { generateCandidates } from './candidate_generator';
 import { probePending } from './prober';
-import { enroll, resetLanguageRejections } from './enroller';
+import { enroll, resetLanguageRejections, requeueAdsTxtHolders } from './enroller';
 
 /**
  * Publisher discovery runner.
@@ -78,11 +78,16 @@ async function main() {
       console.log(`Re-queued ${r.requeued} candidate(s) rejected under the previous language detector.`);
       break;
     }
+    case 'requeue-adstxt-holders': {
+      const r = await requeueAdsTxtHolders();
+      console.log(`Re-queued ${r.requeued} candidate(s) that serve an ads.txt but failed the old SSP-match gate.`);
+      break;
+    }
     case 'stats':
       await printStats();
       break;
     default:
-      console.error('Usage: runner.ts <refresh|probe|enroll|reset-language-rejections|stats> [options]');
+      console.error('Usage: runner.ts <refresh|probe|enroll|reset-language-rejections|requeue-adstxt-holders|stats> [options]');
       process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Why

Enrollment required `ads_txt_valid` — that the ads.txt declares the one `(SSP, seller_id)` pair the candidate happened to be generated from. Including `.jp` (PR #22) showed that gate is now the dominant constraint:

| `.jp` candidates | |
|---|---|
| Serving a real ads.txt | **765** |
| …enrolled | **161 (21%)** |
| …rejected on SSP mismatch alone | **604** |
| No ads.txt / unreachable | 2,094 |

Japanese publishers are typically listed by *domestic* SSPs whose sellers.json entries go stale (i-mobile.co.jp alone accounts for 1,493 exclusions), so the arbitrary pair we picked often is not in the publisher's ads.txt. gTLD candidates were largely spared only because `sellers_catalog` is dominated by Google rows, so Google usually won the arbitrary pick.

This is the same root cause as #20, resolved via that issue's option 2.

## The change

The pipeline exists to widen ads.txt **crawl coverage**, so the criterion that matters is whether a domain publishes an ads.txt at all. Whether a particular seller relationship is still live is visible from the crawled file afterwards — it does not need to gate ingestion.

- New column **`ads_txt_records`**, populated by parsing the fetched ads.txt once. The same pass still yields the SSP match, so there is no extra parse.
- Enrollment gates on `ads_txt_records >= 1`. **`ads_txt_valid` is still recorded** — it remains a useful signal, it just no longer decides.
- `ads_txt_records >= 1` rather than `http_status = 200`: a soft-404 that serves HTML for `/ads.txt` returns 200, and on a 40-domain sample 20% of `200` responses had no parseable records.
- New `requeue-adstxt-holders` command re-queues the **4,122** rows (604 `.jp` + 3,518 gTLD) the old gate rejected despite a live ads.txt. They need a re-probe, not a status flip, because `ads_txt_records` did not exist when they were measured.
- The rejection sweep is the exact negation of the selection, so no qualifying row is retired while it waits for its batch.

## Rollout after merge

`requeue-adstxt-holders` → `probe` → `enroll`. ~4,122 re-probes is well under an hour at 10,000/hour. Scan capacity is ~19,200/day against 1,703/day currently needed, so the extra domains are comfortably absorbed.

## Verification

Migration applied to `ttkit_db`. `tsc --noEmit` clean, **67/67 tests pass**.